### PR TITLE
Bug 2: space after link

### DIFF
--- a/src/libtweetlength.c
+++ b/src/libtweetlength.c
@@ -282,6 +282,8 @@ parse_link_tail (GArray      *entities,
     t = &tokens[i];
 
     if (t->type == TOK_WHITESPACE) {
+      i --;
+      g_debug("Found whitespace - backtracked one to %d", i);
       break;
     }
 

--- a/tests/length.c
+++ b/tests/length.c
@@ -51,6 +51,10 @@ basic_links (void)
   g_assert_cmpint (tl_count_characters ("https://twitter.com."), ==, 24);
   g_assert_cmpint (tl_count_characters ("https://twitter.com("), ==, 24);
 
+  // Neither is white space
+  g_assert_cmpint (tl_count_characters ("https://twitter.com "), ==, 24);
+  g_assert_cmpint (tl_count_characters ("https://twitter.com/ "), ==, 24);
+
   // Punctuation before...
   g_assert_cmpint (tl_count_characters (")https://twitter.com"), ==, 24);
   g_assert_cmpint (tl_count_characters ("?https://twitter.com"), ==, 24);


### PR DESCRIPTION
Tests and fix for bug #2 

It feels like there could be a different way to do the token stepping that avoids so much stepping backwards, but it would involve a *lot* more changes to the code.