### PR TITLE
Bug 4 numbers in hostname

### DIFF
--- a/src/libtweetlength.c
+++ b/src/libtweetlength.c
@@ -352,7 +352,7 @@ parse_link (GArray      *entities,
 
   t = &tokens[i];
 
-  if (t->type != TOK_TEXT) {
+  if (t->type != TOK_TEXT && t->type != TOK_NUMBER) {
     return FALSE;
   }
 
@@ -394,6 +394,7 @@ parse_link (GArray      *entities,
   guint dot_index = i;
   while (dot_index < n_tokens - 1) { // -1 so we can do +1 in the loop body!
     if (tokens[dot_index].type != TOK_TEXT &&
+        tokens[dot_index].type != TOK_NUMBER &&
         tokens[dot_index].type != TOK_DOT) {
       return FALSE;
     }

--- a/tests/entities.c
+++ b/tests/entities.c
@@ -153,6 +153,34 @@ links (void)
 
   g_free (entities);
 
+  // Numbers at the start of domains are also valid - RFC 952 said no but RFC 1123 said yes
+  // https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames
+  entities = tl_extract_entities ("000example.com", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 14);
+
+  g_free (entities);
+
+  // That also allows completely numeric domains (e.g. "123.[many-tlds]" is already registered)
+  entities = tl_extract_entities ("123.com", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 7);
+
+  g_free (entities);
+
+  // But make sure that we don't allow numeric TLD
+  entities = tl_extract_entities ("http://example.000", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 0);
+  g_assert_null (entities);
+
+  g_free (entities);
+
   entities = tl_extract_entities ("twitter.c", &n_entities, NULL);
   g_assert_cmpint (n_entities, ==, 0);
   g_assert_null (entities);


### PR DESCRIPTION
Tests and fix for #4 

By rejecting on `not (text or number or dot)` then we allow valid domains, but keeping the break on `dot followed by text followed that is a TLD` means we don't allow numeric TLDs.