### PR TITLE
Bug 6 double tld parsing

### DIFF
--- a/tests/entities.c
+++ b/tests/entities.c
@@ -251,7 +251,7 @@ links (void)
   g_assert_cmpint (entities[0].length_in_characters, ==, 21);
   
   // 2) Some Brits buy ".uk.com" because the .co.uk and .com are taken (or something)
-  entities = tl_extract_entities ("http://example.uk,com", &n_entities, NULL);
+  entities = tl_extract_entities ("http://example.uk.com", &n_entities, NULL);
   g_assert_cmpint (n_entities, ==, 1);
   g_assert_nonnull (entities);
   g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);

--- a/tests/entities.c
+++ b/tests/entities.c
@@ -228,6 +228,35 @@ links (void)
   g_assert_cmpint (n_entities, ==, 1);
   g_assert_nonnull (entities);
   g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 19);
+
+  g_free (entities);
+
+  entities = tl_extract_entities ("http://example.org.uk", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 21);
+
+  g_free (entities);
+  
+  // And just to make sure that we're not special-casing TLD-like entries:
+  // 1) France normally just has "….fr" but also allows ".com.fr"
+  entities = tl_extract_entities ("http://example.com.fr", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 21);
+  
+  // 2) Some Brits buy ".uk.com" because the .co.uk and .com are taken (or something)
+  entities = tl_extract_entities ("http://example.uk,com", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 21);
 
   g_free (entities);
 


### PR DESCRIPTION
Fix for bug #6 that handles domains with what look like double TLDs

It restructures the checking as a check for a valid first token followed by a two-step look-ahead loop so that it only ever finds the right "a.b.c.d" structure without needing to back-track or special case. It also checks whether each text token is a valid TLD and only passes if the last token was a TLD (so previous TLD-like tokens get ignored in preference of the later TLD-like token)