### PR TITLE
Bug 6 double tld parsing

### DIFF
--- a/src/libtweetlength.c
+++ b/src/libtweetlength.c
@@ -412,7 +412,8 @@ parse_link (GArray      *entities,
         (tokens[i - 1].type == TOK_AT ||
          tokens[i - 1].type == TOK_DOT ||
          tokens[i - 1].type == TOK_SLASH ||
-         tokens[i - 1].type == TOK_DASH)) {
+         tokens[i - 1].type == TOK_DASH ||
+         tokens[i - 1].type == TOK_UNDERSCORE)) {
       return FALSE;
     }
   }
@@ -424,7 +425,7 @@ parse_link (GArray      *entities,
   }
 
   guint scan_position = i;
-  guint tld_index = 0;
+  guint tld_index = i;
 
   g_debug ("Looking for TLD starting from %u", scan_position);
 
@@ -448,7 +449,7 @@ parse_link (GArray      *entities,
   g_debug ("tld_index: %u", tld_index);
 
   if (tld_index != scan_position ||
-      tld_index == 0) {
+      tld_index == i) {
     return FALSE;
   }
 

--- a/src/libtweetlength.c
+++ b/src/libtweetlength.c
@@ -43,6 +43,7 @@ enum {
   TOK_AT,
   TOK_EQUALS,
   TOK_DASH,
+  TOK_UNDERSCORE,
 };
 
 static inline guint
@@ -69,6 +70,8 @@ token_type_from_char (gunichar c)
       return TOK_EQUALS;
     case '-':
       return TOK_DASH;
+    case '_':
+      return TOK_UNDERSCORE;
     case '0':
     case '1':
     case '2':
@@ -219,6 +222,7 @@ char_splits (gunichar c)
     case '@':
     case '#':
     case '-':
+    case '_':
     case '\n':
     case '\t':
     case '\0':
@@ -527,11 +531,16 @@ parse_mention (GArray      *entities,
     return FALSE;
   }
 
-  //skip @
-  i ++;
-  t = &tokens[i];
-  if (t->type != TOK_TEXT &&
-      t->type != TOK_NUMBER) {
+  while (i < n_tokens - 1 &&
+    (
+      tokens[i + 1].type == TOK_TEXT ||
+      tokens[i + 1].type == TOK_NUMBER ||
+      tokens[i + 1].type == TOK_UNDERSCORE
+    )) {
+    i ++;
+  }
+
+  if (i == start_token) {
     return FALSE;
   }
 

--- a/tests/entities.c
+++ b/tests/entities.c
@@ -336,7 +336,7 @@ links (void)
   entities = tl_extract_entities ("I really like http://t.co/pbY2NfTZ's website", &n_entities, &text_length);
   g_assert_cmpint (n_entities, ==, 1);
   g_assert_nonnull (entities);
-  g_assert_cmpint (entities[0].start_character_index, ==, 15);
+  g_assert_cmpint (entities[0].start_character_index, ==, 14);
   g_assert_cmpint (entities[0].length_in_characters, ==, 20);
   g_free (entities);
 
@@ -344,13 +344,12 @@ links (void)
   g_assert_cmpint (n_entities, ==, 1);
   g_assert_nonnull (entities);
   g_assert_cmpint (entities[0].start_character_index, ==, 9);
-  g_assert_cmpint (entities[0].length_in_characters, ==, 20);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 21);
   g_free (entities);
 
-
-  // The it.so one is not a valid link
+  // The it.so ones are not valid links
   entities = tl_extract_entities ("http://twitter.com\nhttp://example.com\nhttp://example.com/path\nexample.com/path\nit.so\nit.so/abcde", &n_entities, &text_length);
-  g_assert_cmpint (n_entities, ==, 5);
+  g_assert_cmpint (n_entities, ==, 4);
   g_assert_nonnull (entities);
   g_free (entities);
 

--- a/tests/entities.c
+++ b/tests/entities.c
@@ -251,7 +251,7 @@ links (void)
   g_assert_cmpint (entities[0].length_in_characters, ==, 21);
   
   // 2) Some Brits buy ".uk.com" because the .co.uk and .com are taken (or something)
-  entities = tl_extract_entities ("http://example.uk,com", &n_entities, NULL);
+  entities = tl_extract_entities ("http://example.uk.com", &n_entities, NULL);
   g_assert_cmpint (n_entities, ==, 1);
   g_assert_nonnull (entities);
   g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);

--- a/tests/entities.c
+++ b/tests/entities.c
@@ -290,23 +290,20 @@ links (void)
   g_assert_null (entities);
   g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("http://foo_bar.com", &n_entities, NULL);*/
-  /*g_assert_cmpint (n_entities, ==, 0);*/
-  /*g_assert_null (entities);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("http://foo_bar.com", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 0);
+  g_assert_null (entities);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("http://trailingunderscore_.foobar.com", &n_entities, NULL);*/
-  /*g_assert_cmpint (n_entities, ==, 0);*/
-  /*g_assert_null (entities);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("http://trailingunderscore_.foobar.com", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 0);
+  g_assert_null (entities);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("http://_leadingunderscore.foobar.com", &n_entities, NULL);*/
-  /*g_assert_cmpint (n_entities, ==, 0);*/
-  /*g_assert_null (entities);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("http://_leadingunderscore.foobar.com", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 0);
+  g_assert_null (entities);
+  g_free (entities);
 
   entities = tl_extract_entities ("http://www.bestbuy.com/site/Currie+Technologies+-+Ezip+400+Scooter/9885188.p?id=1218189013070&skuId=9885188", &n_entities, &text_length);
   g_assert_cmpint (n_entities, ==, 1);
@@ -315,71 +312,62 @@ links (void)
   g_assert_cmpint (text_length, ==, 23);
   g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("http://www.foo.org.za/foo/bar/688.1", &n_entities, &text_length);*/
-  /*g_assert_cmpint (n_entities, ==, 1);*/
-  /*g_assert_nonnull (entities);*/
-  /*g_assert_cmpint (entities[0].start_character_index, ==, 0);*/
-  /*g_assert_cmpint (text_length, ==, 23);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("http://www.foo.org.za/foo/bar/688.1", &n_entities, &text_length);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (text_length, ==, 23);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0", &n_entities, &text_length);*/
-  /*g_assert_cmpint (n_entities, ==, 1);*/
-  /*g_assert_nonnull (entities);*/
-  /*g_assert_cmpint (entities[0].start_character_index, ==, 0);*/
-  /*g_assert_cmpint (text_length, ==, 23);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0", &n_entities, &text_length);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (text_length, ==, 23);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("http://www.cp.sc.edu/events/65", &n_entities, &text_length);*/
-  /*g_assert_cmpint (n_entities, ==, 1);*/
-  /*g_assert_nonnull (entities);*/
-  /*g_assert_cmpint (entities[0].start_character_index, ==, 0);*/
-  /*g_assert_cmpint (text_length, ==, 23);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("http://www.cp.sc.edu/events/65", &n_entities, &text_length);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (text_length, ==, 23);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("I really like http://t.co/pbY2NfTZ's website", &n_entities, &text_length);*/
-  /*g_assert_cmpint (n_entities, ==, 1);*/
-  /*g_assert_nonnull (entities);*/
-  /*g_assert_cmpint (entities[0].start_character_index, ==, 15);*/
-  /*g_assert_cmpint (entities[0].length_in_characters, ==, 20);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("I really like http://t.co/pbY2NfTZ's website", &n_entities, &text_length);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].start_character_index, ==, 15);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 20);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("Trailing http://t.co/pbY2NfTZ- hyphen", &n_entities, &text_length);*/
-  /*g_assert_cmpint (n_entities, ==, 1);*/
-  /*g_assert_nonnull (entities);*/
-  /*g_assert_cmpint (entities[0].start_character_index, ==, 9);*/
-  /*g_assert_cmpint (entities[0].length_in_characters, ==, 20);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("Trailing http://t.co/pbY2NfTZ- hyphen", &n_entities, &text_length);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].start_character_index, ==, 9);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 20);
+  g_free (entities);
 
 
-  // TODO
   // The it.so one is not a valid link
-  /*entities = tl_extract_entities ("http://twitter.com\nhttp://example.com\nhttp://example.com/path\nexample.com/path\nit.so\nit.so/abcde", &n_entities, &text_length);*/
-  /*g_assert_cmpint (n_entities, ==, 5);*/
-  /*g_assert_nonnull (entities);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("http://twitter.com\nhttp://example.com\nhttp://example.com/path\nexample.com/path\nit.so\nit.so/abcde", &n_entities, &text_length);
+  g_assert_cmpint (n_entities, ==, 5);
+  g_assert_nonnull (entities);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("$http://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA", &n_entities, NULL);*/
-  /*g_assert_cmpint (n_entities, ==, 0);*/
-  /*g_assert_null (entities);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("$http://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 0);
+  g_assert_null (entities);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("john.doe.gov@gmail.com", &n_entities, NULL);*/
-  /*g_assert_cmpint (n_entities, ==, 0);*/
-  /*g_assert_null (entities);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("john.doe.gov@gmail.com", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 0);
+  g_assert_null (entities);
+  g_free (entities);
 
-  // TODO
-  /*entities = tl_extract_entities ("http://www.foo.com?referer=https://t.co/abcde", &n_entities, NULL);*/
-  /*g_assert_cmpint (n_entities, ==, 1);*/
-  /*g_assert_nonnull (entities);*/
-  /*g_free (entities);*/
+  entities = tl_extract_entities ("http://www.foo.com?referer=https://t.co/abcde", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_free (entities);
 }
 
 static void

--- a/tests/entities.c
+++ b/tests/entities.c
@@ -228,6 +228,35 @@ links (void)
   g_assert_cmpint (n_entities, ==, 1);
   g_assert_nonnull (entities);
   g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 19);
+
+  g_free (entities);
+
+  entities = tl_extract_entities ("http://example.org.uk", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 21);
+
+  g_free (entities);
+  
+  // And just to make sure that we're not special-casing TLD-like entries:
+  // 1) France normally just has "….fr" but also allows ".com.fr"
+  entities = tl_extract_entities ("http://example.com.fr", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 21);
+  
+  // 2) Some Brits buy ".uk.com" because the .co.uk and .com are taken (or something)
+  entities = tl_extract_entities ("http://example.uk,com", &n_entities, NULL);
+  g_assert_cmpint (n_entities, ==, 1);
+  g_assert_nonnull (entities);
+  g_assert_cmpint (entities[0].type, ==, TL_ENT_LINK);
+  g_assert_cmpint (entities[0].start_character_index, ==, 0);
+  g_assert_cmpint (entities[0].length_in_characters, ==, 21);
 
   g_free (entities);
 


### PR DESCRIPTION
Fix for bug #6 that handles domains with what look like double TLDs

It restructures the checking as a check for a valid first token followed by a two-step look-ahead loop so that it only ever finds the right "a.b.c.d" structure without needing to back-track or special case. It also checks whether each text token is a valid TLD and only passes if the last token was a TLD (so previous TLD-like tokens get ignored in preference of the later TLD-like token). 

It also alters the tokenising a bit to handle some of the new tests that were added, and checks for "starts with bad character" using the `token_in` function (although this still won't find those tokens in the middle of a text string, because of the way that the function works).